### PR TITLE
 transaction currency updation bug fixed --minor-fix

### DIFF
--- a/src/components/TransferBoard/SendFees.jsx
+++ b/src/components/TransferBoard/SendFees.jsx
@@ -92,7 +92,7 @@ function SendFees(props) {
             .then((fromChainWrapper) =>
                 setChainParams(fromChainWrapper.chainParams)
             );
-    }, []);
+    }, [from]);
 
     useEffect(() => {
         console.log(selectedNFTList);


### PR DESCRIPTION
### Problem
The issue was because the state `chainParams` in `SendFees.jsx` that contained the currency to display was not updating when you switch from one chain to another, that is why the currency symbol of the chain selected in only the very first selection remained displayed and never updated. 

### Solution
Adding the `from `state to the dependency array of useEffect responsible for updating the `chainParams` state resolved the issue.